### PR TITLE
SafeArea iOS Fix

### DIFF
--- a/mobile/ios/Flutter/AppFrameworkInfo.plist
+++ b/mobile/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/mobile/ios/Podfile
+++ b/mobile/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+# platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -1,0 +1,56 @@
+PODS:
+  - audio_service (0.0.1):
+    - Flutter
+  - audio_session (0.0.1):
+    - Flutter
+  - Flutter (1.0.0)
+  - FMDB (2.7.11):
+    - FMDB/standard (= 2.7.11)
+  - FMDB/standard (2.7.11)
+  - just_audio (0.0.1):
+    - Flutter
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - sqflite (0.0.3):
+    - Flutter
+    - FMDB (>= 2.7.5)
+
+DEPENDENCIES:
+  - audio_service (from `.symlinks/plugins/audio_service/ios`)
+  - audio_session (from `.symlinks/plugins/audio_session/ios`)
+  - Flutter (from `Flutter`)
+  - just_audio (from `.symlinks/plugins/just_audio/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - sqflite (from `.symlinks/plugins/sqflite/ios`)
+
+SPEC REPOS:
+  trunk:
+    - FMDB
+
+EXTERNAL SOURCES:
+  audio_service:
+    :path: ".symlinks/plugins/audio_service/ios"
+  audio_session:
+    :path: ".symlinks/plugins/audio_session/ios"
+  Flutter:
+    :path: Flutter
+  just_audio:
+    :path: ".symlinks/plugins/just_audio/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  sqflite:
+    :path: ".symlinks/plugins/sqflite/ios"
+
+SPEC CHECKSUMS:
+  audio_service: f509d65da41b9521a61f1c404dd58651f265a567
+  audio_session: 4f3e461722055d21515cf3261b64c973c062f345
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  FMDB: 57486c1117fd8e0e6b947b2f54c3f42bf8e57a4e
+  just_audio: baa7252489dbcf47a4c7cc9ca663e9661c99aafa
+  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
+  sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a
+
+PODFILE CHECKSUM: 2bc9d3cc1c0194714b61828c29463da038fdc4ba
+
+COCOAPODS: 1.15.2

--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		FE18CF25B08EBE6C9ED2733E /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D5E72ADCB3A75BBA26CF7A1 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -31,6 +32,8 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		1939B6681C977E5F96A20143 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		1D5E72ADCB3A75BBA26CF7A1 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -42,6 +45,8 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C19BAFE4BC69615889A5448F /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		DC4CAFBCFA427323822A943E /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -49,12 +54,32 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FE18CF25B08EBE6C9ED2733E /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		14302BED3E01BE9DCCD200C1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1D5E72ADCB3A75BBA26CF7A1 /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3EF9D037413D4BB70453D72B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C19BAFE4BC69615889A5448F /* Pods-Runner.debug.xcconfig */,
+				1939B6681C977E5F96A20143 /* Pods-Runner.release.xcconfig */,
+				DC4CAFBCFA427323822A943E /* Pods-Runner.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -72,6 +97,8 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
+				3EF9D037413D4BB70453D72B /* Pods */,
+				14302BED3E01BE9DCCD200C1 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -105,12 +132,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				E7475638FEAB38A0416E5548 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				973583F82956E19F2922AB19 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -127,7 +156,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -176,6 +205,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -183,6 +213,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		973583F82956E19F2922AB19 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -198,6 +245,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		E7475638FEAB38A0416E5548 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -274,7 +343,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -352,7 +421,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -401,7 +470,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mobile/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/mobile/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/mobile/lib/components/ra_bottomnavbar.dart
+++ b/mobile/lib/components/ra_bottomnavbar.dart
@@ -33,7 +33,6 @@ class RaBottomNavigationBar extends HookWidget {
     final currentIndex = useState(startIconIndex);
     return Container(
       padding: EdgeInsets.only(top: borderWidth),
-      height: 50,
       color: context.colors.highlightGreen,
       child: Container(
         padding: const EdgeInsets.only(left: 20, right: 20),

--- a/mobile/lib/components/radio_player/radio_player_widget.dart
+++ b/mobile/lib/components/radio_player/radio_player_widget.dart
@@ -7,7 +7,7 @@ import 'package:radioaktywne/extensions/extensions.dart';
 import 'package:radioaktywne/state/audio_handler_cubit.dart';
 
 /// The radio player, consisting of a [RaPlayButton]
-/// and a [Marquee] with stream title.
+/// and stream title.
 ///
 /// Should be positioned at the bottom of the screen,
 /// "attached" to the navigation bar
@@ -142,7 +142,7 @@ class _StreamPlayButton extends StatelessWidget {
   }
 }
 
-/// The [Marquee] displaying the radio stream title.
+/// The display of the radio stream title.
 class _StreamTitle extends StatelessWidget {
   const _StreamTitle({
     required this.audioHandler,

--- a/mobile/lib/components/radio_player/radio_player_widget.dart
+++ b/mobile/lib/components/radio_player/radio_player_widget.dart
@@ -2,7 +2,6 @@ import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:leancode_hooks/leancode_hooks.dart';
-import 'package:marquee/marquee.dart';
 import 'package:radioaktywne/components/ra_playbutton.dart';
 import 'package:radioaktywne/extensions/extensions.dart';
 import 'package:radioaktywne/state/audio_handler_cubit.dart';
@@ -161,12 +160,9 @@ class _StreamTitle extends StatelessWidget {
             ? SizedBox(
                 width: MediaQuery.of(context).size.width / 1.6,
                 height: RadioPlayerWidget.height,
-                child: Marquee(
-                  text: mediaItem.title,
-                  blankSpace: 50,
-                  velocity: 10,
-                  // startAfter: const Duration(seconds: 3),
-                  startPadding: 40,
+                // TODO: Zmienić na Marquee zamiast Text
+                child: Text(
+                  mediaItem.title,
                   style: context.textStyles.textPlayer,
                 ),
               )

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -49,210 +49,208 @@ class MainApp extends HookWidget {
       onGenerateTitle: (context) => context.l10n.hello,
       home: BlocProvider(
         create: (_) => AudioHandlerCubit(),
-        child: SafeArea(
-          child: Scaffold(
-            appBar: RaAppBar(
-              height: 75,
-              icon: Icon(
-                Icons.menu,
+        child: Scaffold(
+          appBar: RaAppBar(
+            height: 75,
+            icon: Icon(
+              Icons.menu,
+              color: context.colors.highlightGreen,
+              size: 32,
+              semanticLabel: 'RA AppBar menu button',
+            ),
+            bottomSize: 5,
+            mainColor: context.colors.backgroundDark,
+            accentColor: context.colors.highlightGreen,
+            iconButton: IconButton(
+              onPressed: () => _scaffoldKey.currentState!.isEndDrawerOpen
+                  ? _scaffoldKey.currentState!.closeEndDrawer()
+                  : _scaffoldKey.currentState!.openEndDrawer(),
+              icon: AnimatedIcon(
+                icon: AnimatedIcons.menu_close,
+                progress: burgerMenuIconController,
                 color: context.colors.highlightGreen,
                 size: 32,
                 semanticLabel: 'RA AppBar menu button',
               ),
-              bottomSize: 5,
-              mainColor: context.colors.backgroundDark,
-              accentColor: context.colors.highlightGreen,
-              iconButton: IconButton(
-                onPressed: () => _scaffoldKey.currentState!.isEndDrawerOpen
-                    ? _scaffoldKey.currentState!.closeEndDrawer()
-                    : _scaffoldKey.currentState!.openEndDrawer(),
-                icon: AnimatedIcon(
-                  icon: AnimatedIcons.menu_close,
-                  progress: burgerMenuIconController,
-                  color: context.colors.highlightGreen,
-                  size: 32,
-                  semanticLabel: 'RA AppBar menu button',
-                ),
-              ),
-              text: 'Radio\nAktywne',
-              iconPath: 'assets/ra_logo/RA_logo.svg',
-              titlePadding: const EdgeInsets.only(left: 4, top: 8, bottom: 16),
-              imageHeight: 40,
             ),
-            body: Scaffold(
-              key: _scaffoldKey,
-              backgroundColor: context.colors.backgroundLight,
-              drawerScrimColor: context.colors.drawerBackgroundOverlay,
-              onEndDrawerChanged: (isOpened) => isOpened
-                  ? burgerMenuIconController.forward()
-                  : burgerMenuIconController.reverse(),
-              endDrawer: RaBurgerMenu(
-                titles: const [
-                  'Radio Aktywne',
-                  'Nagrania',
-                  'Płyta tygodnia',
-                  'Publicystyka',
-                  'Radiowcy',
-                  'Ramówka',
-                  'Audycje',
-                  'O nas',
-                ],
-                links: [
-                  () {},
-                  () {},
-                  () {},
-                  () {},
-                  () {},
-                  () {},
-                  () {},
-                  () {},
-                ],
-              ),
-              body: Column(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      /// Ramówka widget
-                      const Padding(
-                        padding: _widgetPadding,
-                        child: RamowkaWidget(),
-                      ),
-
-                      /// Old Ramowka
-                      Padding(
-                        padding: _widgetPadding,
-                        child: ColorShadowedCard(
-                          shadowColor: context.colors.highlightYellow,
-                          header: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 4),
-                            child: Text(
-                              'Ramówka na dziś',
-                              style: context.textStyles.textMedium,
-                            ),
-                          ),
-                          footer: Padding(
-                            padding: const EdgeInsets.only(top: 4),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(horizontal: 2),
-                                  child: Container(
-                                    width: 8,
-                                    height: 8,
-                                    decoration: const BoxDecoration(
-                                      color: Colors.grey,
-                                      shape: BoxShape.circle,
-                                    ),
-                                  ),
-                                ),
-                                Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(horizontal: 2),
-                                  child: Container(
-                                    width: 8,
-                                    height: 8,
-                                    decoration: const BoxDecoration(
-                                      color: Colors.white,
-                                      shape: BoxShape.circle,
-                                    ),
-                                  ),
-                                ),
-                                Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(horizontal: 2),
-                                  child: Container(
-                                    width: 8,
-                                    height: 8,
-                                    decoration: const BoxDecoration(
-                                      color: Colors.grey,
-                                      shape: BoxShape.circle,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          child: Container(
-                            padding: const EdgeInsets.all(20),
-                            child: Text(
-                              'Lorem ipsum',
-                              style: context.textStyles.textSmall,
-                            ),
-                          ),
-                        ),
-                      ),
-                      Padding(
-                        padding: _widgetPadding,
-                        child: Row(
-                          children: [
-                            Expanded(
-                              child: Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 8),
-                                child: ColorShadowedCard(
-                                  shadowColor: context.colors.highlightPurple,
-                                  header: Padding(
-                                    padding:
-                                        const EdgeInsets.symmetric(vertical: 2),
-                                    child: Text(
-                                      'Nagłówek',
-                                      style: context.textStyles.textMedium,
-                                    ),
-                                  ),
-                                  child: Container(
-                                    padding: const EdgeInsets.all(20),
-                                    child: Text(
-                                      'Lorem ipsum',
-                                      style: context.textStyles.textSmall,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
-                            Expanded(
-                              child: Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 8),
-                                child: ColorShadowedCard(
-                                  shadowColor: context.colors.highlightBlue,
-                                  footer: Padding(
-                                    padding:
-                                        const EdgeInsets.symmetric(vertical: 2),
-                                    child: Text(
-                                      'Stopka',
-                                      style: context.textStyles.textSmall,
-                                    ),
-                                  ),
-                                  child: Container(
-                                    padding: const EdgeInsets.all(20),
-                                    child: Text(
-                                      'Lorem ipsum',
-                                      style: context.textStyles.textSmall,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-
-                  /// Radio player widget
-                  const Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 16),
-                    child: RadioPlayerWidget(),
-                  ),
-                ],
-              ),
-            ),
-            bottomNavigationBar: const RaBottomNavigationBar(),
+            text: 'Radio\nAktywne',
+            iconPath: 'assets/ra_logo/RA_logo.svg',
+            titlePadding: const EdgeInsets.only(left: 4, top: 8, bottom: 16),
+            imageHeight: 40,
           ),
+          body: Scaffold(
+            key: _scaffoldKey,
+            backgroundColor: context.colors.backgroundLight,
+            drawerScrimColor: context.colors.drawerBackgroundOverlay,
+            onEndDrawerChanged: (isOpened) => isOpened
+                ? burgerMenuIconController.forward()
+                : burgerMenuIconController.reverse(),
+            endDrawer: RaBurgerMenu(
+              titles: const [
+                'Radio Aktywne',
+                'Nagrania',
+                'Płyta tygodnia',
+                'Publicystyka',
+                'Radiowcy',
+                'Ramówka',
+                'Audycje',
+                'O nas',
+              ],
+              links: [
+                () {},
+                () {},
+                () {},
+                () {},
+                () {},
+                () {},
+                () {},
+                () {},
+              ],
+            ),
+            body: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    /// Ramówka widget
+                    const Padding(
+                      padding: _widgetPadding,
+                      child: RamowkaWidget(),
+                    ),
+        
+                    /// Old Ramowka
+                    Padding(
+                      padding: _widgetPadding,
+                      child: ColorShadowedCard(
+                        shadowColor: context.colors.highlightYellow,
+                        header: Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 4),
+                          child: Text(
+                            'Ramówka na dziś',
+                            style: context.textStyles.textMedium,
+                          ),
+                        ),
+                        footer: Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 2),
+                                child: Container(
+                                  width: 8,
+                                  height: 8,
+                                  decoration: const BoxDecoration(
+                                    color: Colors.grey,
+                                    shape: BoxShape.circle,
+                                  ),
+                                ),
+                              ),
+                              Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 2),
+                                child: Container(
+                                  width: 8,
+                                  height: 8,
+                                  decoration: const BoxDecoration(
+                                    color: Colors.white,
+                                    shape: BoxShape.circle,
+                                  ),
+                                ),
+                              ),
+                              Padding(
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 2),
+                                child: Container(
+                                  width: 8,
+                                  height: 8,
+                                  decoration: const BoxDecoration(
+                                    color: Colors.grey,
+                                    shape: BoxShape.circle,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        child: Container(
+                          padding: const EdgeInsets.all(20),
+                          child: Text(
+                            'Lorem ipsum',
+                            style: context.textStyles.textSmall,
+                          ),
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: _widgetPadding,
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 8),
+                              child: ColorShadowedCard(
+                                shadowColor: context.colors.highlightPurple,
+                                header: Padding(
+                                  padding:
+                                      const EdgeInsets.symmetric(vertical: 2),
+                                  child: Text(
+                                    'Nagłówek',
+                                    style: context.textStyles.textMedium,
+                                  ),
+                                ),
+                                child: Container(
+                                  padding: const EdgeInsets.all(20),
+                                  child: Text(
+                                    'Lorem ipsum',
+                                    style: context.textStyles.textSmall,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 8),
+                              child: ColorShadowedCard(
+                                shadowColor: context.colors.highlightBlue,
+                                footer: Padding(
+                                  padding:
+                                      const EdgeInsets.symmetric(vertical: 2),
+                                  child: Text(
+                                    'Stopka',
+                                    style: context.textStyles.textSmall,
+                                  ),
+                                ),
+                                child: Container(
+                                  padding: const EdgeInsets.all(20),
+                                  child: Text(
+                                    'Lorem ipsum',
+                                    style: context.textStyles.textSmall,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+        
+                /// Radio player widget
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16),
+                  child: RadioPlayerWidget(),
+                ),
+              ],
+            ),
+          ),
+          bottomNavigationBar: const RaBottomNavigationBar(),
         ),
       ),
     );

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -10,19 +10,20 @@ import 'package:radioaktywne/components/ra_bottomnavbar.dart';
 import 'package:radioaktywne/components/ra_burger_menu.dart';
 import 'package:radioaktywne/extensions/extensions.dart';
 import 'package:radioaktywne/l10n/localizations.dart';
+import 'package:radioaktywne/resources/colors.dart';
 import 'package:radioaktywne/state/audio_handler_cubit.dart';
 
 import 'components/radio_player/radio_player_widget.dart';
 import 'components/ramowka/ramowka_widget.dart';
 
 void main() {
-  // TODO: Think about better solution using
-  // TODO: (access to RAColors)
+  /// Sadly: only (known) way to do this on Android
+  /// (works just fine without this on iOS)
   if (Platform.isAndroid) {
     SystemChrome.setSystemUIOverlayStyle(
       SystemUiOverlayStyle.light.copyWith(
-        statusBarColor: const Color(0xFF302318),
-        systemNavigationBarColor: const Color(0xFF302318),
+        statusBarColor: const ColorsLight().backgroundDark,
+        systemNavigationBarColor: const ColorsLight().backgroundDark,
       ),
     );
   }
@@ -53,6 +54,7 @@ class MainApp extends HookWidget {
       duration: const Duration(milliseconds: 450),
       reverseDuration: const Duration(milliseconds: 250),
     );
+
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: context.theme,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -148,7 +146,7 @@ class MainApp extends HookWidget {
                                 children: [
                                   Padding(
                                     padding: const EdgeInsets.symmetric(
-                                        horizontal: 2),
+                                        horizontal: 2,),
                                     child: Container(
                                       width: 8,
                                       height: 8,
@@ -160,7 +158,7 @@ class MainApp extends HookWidget {
                                   ),
                                   Padding(
                                     padding: const EdgeInsets.symmetric(
-                                        horizontal: 2),
+                                        horizontal: 2,),
                                     child: Container(
                                       width: 8,
                                       height: 8,
@@ -172,7 +170,7 @@ class MainApp extends HookWidget {
                                   ),
                                   Padding(
                                     padding: const EdgeInsets.symmetric(
-                                        horizontal: 2),
+                                        horizontal: 2,),
                                     child: Container(
                                       width: 8,
                                       height: 8,
@@ -206,7 +204,7 @@ class MainApp extends HookWidget {
                                     shadowColor: context.colors.highlightPurple,
                                     header: Padding(
                                       padding: const EdgeInsets.symmetric(
-                                          vertical: 2),
+                                          vertical: 2,),
                                       child: Text(
                                         'Nagłówek',
                                         style: context.textStyles.textMedium,
@@ -230,7 +228,7 @@ class MainApp extends HookWidget {
                                     shadowColor: context.colors.highlightBlue,
                                     footer: Padding(
                                       padding: const EdgeInsets.symmetric(
-                                          vertical: 2),
+                                          vertical: 2,),
                                       child: Text(
                                         'Stopka',
                                         style: context.textStyles.textSmall,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -146,8 +148,7 @@ class MainApp extends HookWidget {
                                 children: [
                                   Padding(
                                     padding: const EdgeInsets.symmetric(
-                                      horizontal: 2,
-                                    ),
+                                        horizontal: 2),
                                     child: Container(
                                       width: 8,
                                       height: 8,
@@ -159,8 +160,7 @@ class MainApp extends HookWidget {
                                   ),
                                   Padding(
                                     padding: const EdgeInsets.symmetric(
-                                      horizontal: 2,
-                                    ),
+                                        horizontal: 2),
                                     child: Container(
                                       width: 8,
                                       height: 8,
@@ -261,11 +261,7 @@ class MainApp extends HookWidget {
                 ),
               ),
             ),
-            bottomNavigationBar: Theme(
-              data: Theme.of(context)
-                  .copyWith(canvasColor: context.colors.backgroundDark),
-              child: const RaBottomNavigationBar(),
-            ),
+            bottomNavigationBar: const RaBottomNavigationBar(),
           ),
         ),
       ),

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -10,24 +8,12 @@ import 'package:radioaktywne/components/ra_bottomnavbar.dart';
 import 'package:radioaktywne/components/ra_burger_menu.dart';
 import 'package:radioaktywne/extensions/extensions.dart';
 import 'package:radioaktywne/l10n/localizations.dart';
-import 'package:radioaktywne/resources/colors.dart';
 import 'package:radioaktywne/state/audio_handler_cubit.dart';
 
 import 'components/radio_player/radio_player_widget.dart';
 import 'components/ramowka/ramowka_widget.dart';
 
 void main() {
-  /// Sadly: only (known) way to do this on Android
-  /// (works just fine without this on iOS)
-  if (Platform.isAndroid) {
-    SystemChrome.setSystemUIOverlayStyle(
-      SystemUiOverlayStyle.light.copyWith(
-        statusBarColor: const ColorsLight().backgroundDark,
-        systemNavigationBarColor: const ColorsLight().backgroundDark,
-      ),
-    );
-  }
-
   /// Setup so the orientation stays in portrait mode
   ///
   /// Also, in the AndroidManifest.xml file,
@@ -66,213 +52,220 @@ class MainApp extends HookWidget {
       onGenerateTitle: (context) => context.l10n.hello,
       home: BlocProvider(
         create: (_) => AudioHandlerCubit(),
-        child: Scaffold(
-          appBar: RaAppBar(
-            height: 75,
-            icon: Icon(
-              Icons.menu,
-              color: context.colors.highlightGreen,
-              size: 32,
-              semanticLabel: 'RA AppBar menu button',
-            ),
-            bottomSize: 5,
-            mainColor: context.colors.backgroundDark,
-            accentColor: context.colors.highlightGreen,
-            iconButton: IconButton(
-              onPressed: () => _scaffoldKey.currentState!.isEndDrawerOpen
-                  ? _scaffoldKey.currentState!.closeEndDrawer()
-                  : _scaffoldKey.currentState!.openEndDrawer(),
-              icon: AnimatedIcon(
-                icon: AnimatedIcons.menu_close,
-                progress: burgerMenuIconController,
+        child: AnnotatedRegion(
+          value: SystemUiOverlayStyle(
+            systemNavigationBarColor: context.colors.backgroundDark,
+          ),
+          child: Scaffold(
+            appBar: RaAppBar(
+              height: 75,
+              icon: Icon(
+                Icons.menu,
                 color: context.colors.highlightGreen,
                 size: 32,
                 semanticLabel: 'RA AppBar menu button',
               ),
-            ),
-            text: 'Radio\nAktywne',
-            iconPath: 'assets/ra_logo/RA_logo.svg',
-            titlePadding: const EdgeInsets.only(left: 4, top: 8, bottom: 16),
-            imageHeight: 40,
-          ),
-          body: SafeArea (
-            child: Scaffold(
-              key: _scaffoldKey,
-              backgroundColor: Colors.transparent,
-              drawerScrimColor: context.colors.drawerBackgroundOverlay,
-              onEndDrawerChanged: (isOpened) => isOpened
-                  ? burgerMenuIconController.forward()
-                  : burgerMenuIconController.reverse(),
-              endDrawer: RaBurgerMenu(
-                titles: const [
-                  'Radio Aktywne',
-                  'Nagrania',
-                  'Płyta tygodnia',
-                  'Publicystyka',
-                  'Radiowcy',
-                  'Ramówka',
-                  'Audycje',
-                  'O nas',
-                ],
-                links: [
-                  () {},
-                  () {},
-                  () {},
-                  () {},
-                  () {},
-                  () {},
-                  () {},
-                  () {},
-                ],
+              bottomSize: 5,
+              mainColor: context.colors.backgroundDark,
+              accentColor: context.colors.highlightGreen,
+              iconButton: IconButton(
+                onPressed: () => _scaffoldKey.currentState!.isEndDrawerOpen
+                    ? _scaffoldKey.currentState!.closeEndDrawer()
+                    : _scaffoldKey.currentState!.openEndDrawer(),
+                icon: AnimatedIcon(
+                  icon: AnimatedIcons.menu_close,
+                  progress: burgerMenuIconController,
+                  color: context.colors.highlightGreen,
+                  size: 32,
+                  semanticLabel: 'RA AppBar menu button',
+                ),
               ),
-              body: Column(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      /// Ramówka widget
-                      const Padding(
-                        padding: _widgetPadding,
-                        child: RamowkaWidget(),
-                      ),
-                    
-                      /// Old Ramowka
-                      Padding(
-                        padding: _widgetPadding,
-                        child: ColorShadowedCard(
-                          shadowColor: context.colors.highlightYellow,
-                          header: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 4),
-                            child: Text(
-                              'Ramówka na dziś',
-                              style: context.textStyles.textMedium,
+              text: 'Radio\nAktywne',
+              iconPath: 'assets/ra_logo/RA_logo.svg',
+              titlePadding: const EdgeInsets.only(left: 4, top: 8, bottom: 16),
+              imageHeight: 40,
+            ),
+            body: SafeArea(
+              child: Scaffold(
+                key: _scaffoldKey,
+                backgroundColor: Colors.transparent,
+                drawerScrimColor: context.colors.drawerBackgroundOverlay,
+                onEndDrawerChanged: (isOpened) => isOpened
+                    ? burgerMenuIconController.forward()
+                    : burgerMenuIconController.reverse(),
+                endDrawer: RaBurgerMenu(
+                  titles: const [
+                    'Radio Aktywne',
+                    'Nagrania',
+                    'Płyta tygodnia',
+                    'Publicystyka',
+                    'Radiowcy',
+                    'Ramówka',
+                    'Audycje',
+                    'O nas',
+                  ],
+                  links: [
+                    () {},
+                    () {},
+                    () {},
+                    () {},
+                    () {},
+                    () {},
+                    () {},
+                    () {},
+                  ],
+                ),
+                body: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        /// Ramówka widget
+                        const Padding(
+                          padding: _widgetPadding,
+                          child: RamowkaWidget(),
+                        ),
+
+                        /// Old Ramowka
+                        Padding(
+                          padding: _widgetPadding,
+                          child: ColorShadowedCard(
+                            shadowColor: context.colors.highlightYellow,
+                            header: Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 4),
+                              child: Text(
+                                'Ramówka na dziś',
+                                style: context.textStyles.textMedium,
+                              ),
                             ),
-                          ),
-                          footer: Padding(
-                            padding: const EdgeInsets.only(top: 4),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(horizontal: 2),
-                                  child: Container(
-                                    width: 8,
-                                    height: 8,
-                                    decoration: const BoxDecoration(
-                                      color: Colors.grey,
-                                      shape: BoxShape.circle,
+                            footer: Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 2,
+                                    ),
+                                    child: Container(
+                                      width: 8,
+                                      height: 8,
+                                      decoration: const BoxDecoration(
+                                        color: Colors.grey,
+                                        shape: BoxShape.circle,
+                                      ),
                                     ),
                                   ),
-                                ),
-                                Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(horizontal: 2),
-                                  child: Container(
-                                    width: 8,
-                                    height: 8,
-                                    decoration: const BoxDecoration(
-                                      color: Colors.white,
-                                      shape: BoxShape.circle,
+                                  Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 2,
+                                    ),
+                                    child: Container(
+                                      width: 8,
+                                      height: 8,
+                                      decoration: const BoxDecoration(
+                                        color: Colors.white,
+                                        shape: BoxShape.circle,
+                                      ),
                                     ),
                                   ),
-                                ),
-                                Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(horizontal: 2),
-                                  child: Container(
-                                    width: 8,
-                                    height: 8,
-                                    decoration: const BoxDecoration(
-                                      color: Colors.grey,
-                                      shape: BoxShape.circle,
+                                  Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                        horizontal: 2),
+                                    child: Container(
+                                      width: 8,
+                                      height: 8,
+                                      decoration: const BoxDecoration(
+                                        color: Colors.grey,
+                                        shape: BoxShape.circle,
+                                      ),
                                     ),
                                   ),
-                                ),
-                              ],
+                                ],
+                              ),
                             ),
-                          ),
-                          child: Container(
-                            padding: const EdgeInsets.all(20),
-                            child: Text(
-                              'Lorem ipsum',
-                              style: context.textStyles.textSmall,
+                            child: Container(
+                              padding: const EdgeInsets.all(20),
+                              child: Text(
+                                'Lorem ipsum',
+                                style: context.textStyles.textSmall,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                      Padding(
-                        padding: _widgetPadding,
-                        child: Row(
-                          children: [
-                            Expanded(
-                              child: Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 8),
-                                child: ColorShadowedCard(
-                                  shadowColor: context.colors.highlightPurple,
-                                  header: Padding(
-                                    padding:
-                                        const EdgeInsets.symmetric(vertical: 2),
-                                    child: Text(
-                                      'Nagłówek',
-                                      style: context.textStyles.textMedium,
+                        Padding(
+                          padding: _widgetPadding,
+                          child: Row(
+                            children: [
+                              Expanded(
+                                child: Padding(
+                                  padding:
+                                      const EdgeInsets.symmetric(horizontal: 8),
+                                  child: ColorShadowedCard(
+                                    shadowColor: context.colors.highlightPurple,
+                                    header: Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                          vertical: 2),
+                                      child: Text(
+                                        'Nagłówek',
+                                        style: context.textStyles.textMedium,
+                                      ),
                                     ),
-                                  ),
-                                  child: Container(
-                                    padding: const EdgeInsets.all(20),
-                                    child: Text(
-                                      'Lorem ipsum',
-                                      style: context.textStyles.textSmall,
+                                    child: Container(
+                                      padding: const EdgeInsets.all(20),
+                                      child: Text(
+                                        'Lorem ipsum',
+                                        style: context.textStyles.textSmall,
+                                      ),
                                     ),
                                   ),
                                 ),
                               ),
-                            ),
-                            Expanded(
-                              child: Padding(
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 8),
-                                child: ColorShadowedCard(
-                                  shadowColor: context.colors.highlightBlue,
-                                  footer: Padding(
-                                    padding:
-                                        const EdgeInsets.symmetric(vertical: 2),
-                                    child: Text(
-                                      'Stopka',
-                                      style: context.textStyles.textSmall,
+                              Expanded(
+                                child: Padding(
+                                  padding:
+                                      const EdgeInsets.symmetric(horizontal: 8),
+                                  child: ColorShadowedCard(
+                                    shadowColor: context.colors.highlightBlue,
+                                    footer: Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                          vertical: 2),
+                                      child: Text(
+                                        'Stopka',
+                                        style: context.textStyles.textSmall,
+                                      ),
                                     ),
-                                  ),
-                                  child: Container(
-                                    padding: const EdgeInsets.all(20),
-                                    child: Text(
-                                      'Lorem ipsum',
-                                      style: context.textStyles.textSmall,
+                                    child: Container(
+                                      padding: const EdgeInsets.all(20),
+                                      child: Text(
+                                        'Lorem ipsum',
+                                        style: context.textStyles.textSmall,
+                                      ),
                                     ),
                                   ),
                                 ),
                               ),
-                            ),
-                          ],
+                            ],
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                    
-                  /// Radio player widget
-                  const Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 16),
-                    child: RadioPlayerWidget(),
-                  ),
-                ],
+                      ],
+                    ),
+
+                    /// Radio player widget
+                    const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      child: RadioPlayerWidget(),
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-          bottomNavigationBar: Theme(
-            data: Theme.of(context)
-                .copyWith(canvasColor: context.colors.backgroundDark),
-            child: const RaBottomNavigationBar(),
+            bottomNavigationBar: Theme(
+              data: Theme.of(context)
+                  .copyWith(canvasColor: context.colors.backgroundDark),
+              child: const RaBottomNavigationBar(),
+            ),
           ),
         ),
       ),

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -14,6 +16,17 @@ import 'components/radio_player/radio_player_widget.dart';
 import 'components/ramowka/ramowka_widget.dart';
 
 void main() {
+  // TODO: Think about better solution using
+  // TODO: (access to RAColors)
+  if (Platform.isAndroid) {
+    SystemChrome.setSystemUIOverlayStyle(
+      SystemUiOverlayStyle.light.copyWith(
+        statusBarColor: const Color(0xFF302318),
+        systemNavigationBarColor: const Color(0xFF302318),
+      ),
+    );
+  }
+
   /// Setup so the orientation stays in portrait mode
   ///
   /// Also, in the AndroidManifest.xml file,
@@ -118,7 +131,7 @@ class MainApp extends HookWidget {
                       padding: _widgetPadding,
                       child: RamowkaWidget(),
                     ),
-        
+
                     /// Old Ramowka
                     Padding(
                       padding: _widgetPadding,
@@ -241,7 +254,7 @@ class MainApp extends HookWidget {
                     ),
                   ],
                 ),
-        
+
                 /// Radio player widget
                 const Padding(
                   padding: EdgeInsets.symmetric(horizontal: 16),
@@ -250,7 +263,11 @@ class MainApp extends HookWidget {
               ],
             ),
           ),
-          bottomNavigationBar: const RaBottomNavigationBar(),
+          bottomNavigationBar: Theme(
+            data: Theme.of(context)
+                .copyWith(canvasColor: context.colors.backgroundDark),
+            child: const RaBottomNavigationBar(),
+          ),
         ),
       ),
     );

--- a/mobile/lib/resources/colors.dart
+++ b/mobile/lib/resources/colors.dart
@@ -31,9 +31,9 @@ abstract class RAColors {
   static RAColors ofBrightness(Brightness brightness) {
     switch (brightness) {
       case Brightness.light:
-        return const _ColorsLight();
+        return const ColorsLight();
       case Brightness.dark:
-        return const _ColorsLight();
+        return const ColorsLight();
     }
   }
 
@@ -53,8 +53,8 @@ abstract class RAColors {
   RAColor get drawerBackgroundOverlay;
 }
 
-class _ColorsLight extends RAColors {
-  const _ColorsLight() : super._();
+class ColorsLight extends RAColors {
+  const ColorsLight() : super._();
   // backgrounds
   @override
   RAColor get backgroundLight => const RAColor._(0xFFFFF4DB);

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   color:
     dependency: transitive
     description:
@@ -257,14 +257,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  fading_edge_scrollview:
-    dependency: transitive
-    description:
-      name: fading_edge_scrollview
-      sha256: c25c2231652ce774cc31824d0112f11f653881f43d7f5302c05af11942052031
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -481,10 +473,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   io:
     dependency: transitive
     description:
@@ -541,6 +533,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.8"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   leancode_hooks:
     dependency: "direct main"
     description:
@@ -573,38 +589,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  marquee:
-    dependency: "direct main"
-    description:
-      name: marquee
-      sha256: "4b5243d2804373bdc25fc93d42c3b402d6ec1f4ee8d0bb72276edd04ae7addb8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.3"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -617,10 +625,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "7d5b53bcd556c1bc7ffbe4e4d5a19c3e112b7e925e9e172dd7c6ad0630812616"
+      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.2"
+    version: "5.4.4"
   nested:
     dependency: transitive
     description:
@@ -649,10 +657,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_parsing:
     dependency: transitive
     description:
@@ -862,18 +870,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -910,10 +918,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.0"
   time:
     dependency: transitive
     description:
@@ -978,6 +986,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -986,14 +1002,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1035,5 +1043,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.7.9"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -22,12 +22,11 @@ dependencies:
   freezed_annotation: ^2.2.0
   go_router: ^6.5.0
   http: ^1.1.0
-  intl: ^0.18.0
+  intl: ^0.19.0
   json_annotation: ^4.8.0
   just_audio: ^0.9.34
   leancode_hooks: ^0.0.3+1
   logging: ^1.1.1
-  marquee: ^2.2.3
   oktoast: ^3.3.1
   provider: ^6.0.5
   rxdart: ^0.27.7


### PR DESCRIPTION
## Małe zmiany
- Zmiana intl: ^0.18.0 na intl: ^0.19.0, tak aby wspierany był Flutter 3.22.2.
- Usunięcie marquee, ponieważ nie jest już wspierane przez tą wersję Flutter (fix tego jest już zrobiony przez Julka)

## Poprawka SafeArea
- Usunięcie ```height: 50``` z 36 linijki w bottom nav barze, co powodowało problem z overflowem
- przeniesienie widgetu SafeArea pod Scaffold-a tak jak dyskutowaliśmy (czat GPT twierdzi natomiast, że Scaffold automatycznie zarządza paddingiem i SafeArea wrapper w ogóle nie jest potrzebny, a nawet może powodować problemy)
- Przeniesiony scaffold backgroundColor do 'theme' w widgecie MaterialApp dla lepszej czytelności
- wprowadzenie, fix-u też dla androida gdzie problem był, że aplikacja nie wypełniałą całego ekranu od dołu:
```dart
child: AnnotatedRegion(
          value: SystemUiOverlayStyle(
            systemNavigationBarColor: context.colors.backgroundDark
```
Jako dowód na to że wypełnia aplikacja cały ekran na iOS bez interaktywnych elementów poza SafeArea
<img src="https://github.com/RadioAktywne/ra-app/assets/101600853/c76794f1-2944-42bd-b2c9-01dcf399a624" width="300">

